### PR TITLE
Add check.names=FALSE in CIRI_DE.R

### DIFF
--- a/libs/CIRI_DE.R
+++ b/libs/CIRI_DE.R
@@ -31,9 +31,9 @@ if (is.na(opt$lib) || is.na(opt$bsj) || is.na(opt$gene) || is.na(opt$out)) {
 
 # Load data
 lib_mtx <- read.csv(opt$lib, row.names = 1)
-gene_mtx <- read.csv(opt$gene, row.names = 1)
+gene_mtx <- read.csv(opt$gene, row.names = 1, check.names=FALSE)
 gene_mtx <- gene_mtx[,rownames(lib_mtx)]
-bsj_mtx <- read.csv(opt$bsj, row.names = 1)
+bsj_mtx <- read.csv(opt$bsj, row.names = 1, check.names=FALSE)
 
 gene_DGE <- DGEList(counts = gene_mtx, group = lib_mtx$Group)
 gene_idx <- filterByExpr(gene_DGE)


### PR DESCRIPTION
Add check.names=FALSE in CIRI_DE.R  to lines for reading in the gene and BSJ count tables; this should remove any sample_id associated errors, especially when sample_id starts with a number.